### PR TITLE
feat: add filename formatter Shell script

### DIFF
--- a/filename_formatter.sh
+++ b/filename_formatter.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+echo -e "Arguments:
+[0] - Used by Bash (script filename)
+[1] - Base directory
+[2] - Filename type (maximum two values)
+[3] - Ignored files or folders (optional; use "\""./<directory_name>"\"")
+"
+
+echo "Changed files:"
+
+# Separate $2 value (filename types) if it has a comma
+if [[ "$2" == *","* ]];
+then
+string="$2"
+
+str_value=${string#*,}
+str_value2=${string%%,*}
+else
+str_value="$2"
+str_value2="$2"
+fi
+
+IFS=$'\n'
+for fname in `find $1 -type f -name "$str_value2" -o -name "$str_value"`
+do
+    ignored_files="$(echo $3 | tr "," "\n")"
+
+    str="${fname}"
+    value=${str%/*} # If the base directory is `.`, check in all directories for the ignored filenames
+
+    for files in $ignored_files
+    do
+        if [ "${fname}" == "$value/$files" ] || [ "$value" == "$files" ];
+        then
+            continue 2
+        fi
+    done
+
+    #echo ${fname}
+    new_fname=`echo ${fname} | tr ' ' '_'`
+    #echo "      ${new_fname}"
+    new_fname=`echo ${new_fname} | tr 'A-Z' 'a-z'`
+    #echo "      ${new_fname}"
+    new_fname=`echo ${new_fname} | tr '-' '_'`
+    #echo "      ${new_fname}"
+    if [ ${fname} != ${new_fname} ]
+    then
+        echo "      ${fname} --> ${new_fname}"
+        git "mv" "${fname}" ${new_fname} # Requires you to be in version control
+    fi
+done


### PR DESCRIPTION
Things added/changed:

- Add a Shell filename formatter script. The script lets you:
  - Choose the desired base directory.
  - Choose between two file types (e.g.: `*.cpp`, `*.hpp`).
  - Ignore files and directories to not be checked (filenames do not need to include directories as all directories are checked if they have the same filename).
  - Why add it here? It's already being used in various repositories such as the [**C**](https://github.com/TheAlgorithms/C)/[**C++**](https://github.com/TheAlgorithms/C-Plus-Plus), [**Julia**](https://github.com/TheAlgorithms/Julia), [**TypeScript**](https://github.com/TheAlgorithms/TypeScript), and hopefully more repositories.

I'm not a Shell expert, so if you have any improvements that can be done, let me know. Thanks. 🙂
CC: @uncomfyhalomacro, you might want to check this as you're better with Shell scripts.
