### PR TITLE
Fixing formatter action

### DIFF
--- a/formatter/action.yml
+++ b/formatter/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Running the formatter
       shell: bash
       run: |
-        ./filename_formatter.sh ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignore-files }}
+        filename_formatter.sh ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignore-files }}
     - name: Committing changes
       shell: bash
       run: |


### PR DESCRIPTION
The actions are failing because `./formatter.sh` tries to look for the file in the root of the repository which is calling the action which doesn't exist. The way we had fixed this was to use the `action_path` modification to use that but might have overlooked the change in the previous PR. 