### PR TITLE
Create a pull request instead of committing directly

### DIFF
--- a/directory_md/action.yml
+++ b/directory_md/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10' # or whatever version you support
+        python-version: '3.x'  # or whatever version you support
     - name: Running the formatter
       shell: bash
       run: |

--- a/directory_md/action.yml
+++ b/directory_md/action.yml
@@ -27,17 +27,24 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.10' # or whatever version you support
-    - name: Setup Git configurations
-      shell: bash
-      run: |
-        git config --global user.name github-actions[bot]
-        git config --global user.email 'github-actions@users.noreply.github.com'
     - name: Running the formatter
       shell: bash
       run: |
         python build_directory_md.py ${{ inputs.language }} ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignored-directories }} ${{ inputs.ignore-folders-children }} > DIRECTORY.md
-    - name: Committing changes
+
+        git pull || true
+    - name: Committing and pushing changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      id: commit-push
+      with:
+        commit_message: "docs: updating `DIRECTORY.md`"
+        branch: "directory-${{ github.sha }}"
+        create_branch: true
+    - name: Creating and merging the PR
       shell: bash
+      if: steps.commit-push.outputs.changes_detected == 'true'
       run: |
-        git commit -m "chore: update `DIRECTORY.md`" DIRECTORY.md || true
-        git push origin HEAD:$GITHUB_REF || true
+        gh pr create --base ${GITHUB_REF##*/} --head directory-${{ github.sha }} --title 'docs: updating `DIRECTORY.md`' --body '`DIRECTORY.md` has been updated (see the diff. for changes).'
+        gh pr merge --admin --merge --subject 'docs: updating `DIRECTORY.md`' --delete-branch
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/formatter/action.yml
+++ b/formatter/action.yml
@@ -17,19 +17,24 @@ runs:
   steps:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
-    - name: Setup Git configurations
-      shell: bash
-      run: |
-        git config --global user.name github-actions[bot]
-        git config --global user.email 'github-actions@users.noreply.github.com'
     - name: Running the formatter
       shell: bash
       run: |
         filename_formatter.sh ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignore-files }}
-    - name: Committing changes
-      shell: bash
-      run: |
-        git add ${{ inputs.working-directory }} || true
-        git commit -m "chore: formatting filenames" || true
 
-        git push origin HEAD:$GITHUB_REF || true
+        git pull || true
+    - name: Committing and pushing changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      id: commit-push
+      with:
+        commit_message: "chore: formatting filenames"
+        branch: "formatting_files-${{ github.sha }}"
+        create_branch: true
+    - name: Creating and merging the PR
+      shell: bash
+      if: steps.commit-push.outputs.changes_detected == 'true'
+      run: |
+        gh pr create --base ${GITHUB_REF##*/} --head formatting_files-${{ github.sha }} --title 'chore: formatting filenames' --body 'Formatted filenames (see the diff. for changes).'
+        gh pr merge --admin --merge --subject 'chore: formatting filenames' --delete-branch
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Things added/changed:

- Create a pull request instead of committing directly.
  - The actions will now create a new branch with the current GitHub SHA, create a pull request, and merge it to the original branch (using `GITHUB_REF`). The branch will be later on deleted to keep things clean.
  - Tested and works. You can see all the (unclean) testing [here](https://github.com/Panquesito7/scripts/tree/test).
