### PR TITLE
Fix directory workflow script

### DIFF
--- a/directory_md/action.yml
+++ b/directory_md/action.yml
@@ -35,18 +35,29 @@ runs:
     - name: Running the directory builder
       shell: bash
       run: |
-        python build_directory_md.py ${{ inputs.language }} ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignored-directories }} ${{ inputs.ignore-folders-children }} > DIRECTORY.md
-    - name: Committing changes
-      shell: bash
-      run: |
-        git branch directory-update
-        git checkout directory-update
+        # If branch exists, change to that branch to prevent multiple committing/PR creation.
+        git checkout directory-update || true
 
-        git commit -m "docs: update `DIRECTORY.md`" DIRECTORY.md || true
-        git push origin directory-update:directory-update --force
-    - name: Creating a pull request
+        python build_directory_md.py ${{ inputs.language }} ${{ inputs.working-directory }} ${{ inputs.filetypes }} ${{ inputs.ignored-directories }} ${{ inputs.ignore-folders-children }} > DIRECTORY.md
+    - name: Creating a branch
       shell: bash
       run: |
-          if [[ `git status --porcelain` ]]; then
+        git branch directory-update || true
+        git checkout directory-update || true
+
+    - name: Committing, pushing, and creating a PR
+      shell: bash
+      run: |
+        if [[ `git status --porcelain` ]];
+        then
+
+          git add DIRECTORY.md
+
+          git commit -m "docs: update DIRECTORY.md" || true
+          git push origin directory-update:directory-update --force
+
           gh pr create --base ${GITHUB_REF##*/} --head directory-update --title 'docs: updating `DIRECTORY.md`' --body 'Updated the `DIRECTORY.md` file (see the diff. for changes).' || true
-      # `true` is needed in case the PR has been already created to prevent the CI to fail. The changes will already be pushed to the current PR's branch.
+          # Using `true` will make sure no errors are displayed even if there's a PR created.
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Things added/changed:

- Fix directory workflow script.
  - Commits/pushing/PR creation will be done ONLY if there are changes found.
  - If there are no changes found, nothing will be done.
  - The branch `directory-update` will be used for everything. I'm thinking we should either allow the user to choose what branch name, or generate a new branch for each commit (this will also prevent a lot of problems). Please let me know your choice. 🙂
